### PR TITLE
Task/cia 79 cocoa pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ gradle.properties
 
 # Vertx Config files
 **/config.json
+
+# Temporary Mac Files
+**/.DS_Store

--- a/Protos.podspec
+++ b/Protos.podspec
@@ -1,0 +1,135 @@
+#
+#  Be sure to run `pod spec lint Protos.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  spec.name         = "Protos"
+  spec.version      = "1.0.0"
+  spec.summary      = "The protocol buffer specification to create the Cyface binary format"
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  spec.description  = <<-DESC
+This Project contains the measurement.proto file.
+It serves as input description for the Cyface binary format, starting with version 2.
+                   DESC
+
+  spec.homepage     = "https://github.com/cyface-de/protos"
+  # spec.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See https://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  spec.license      = "GPLv3"
+  # spec.license      = { :type => "GPLv3", :file => "LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  spec.author             = { "Cyface GmbH" => "mail@cyface.de" }
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # spec.platform     = :ios
+  # spec.platform     = :ios, "5.0"
+
+  #  When using multiple platforms
+  spec.ios.deployment_target = "12.0"
+  spec.osx.deployment_target = "10.9"
+  # spec.watchos.deployment_target = "2.0"
+  # spec.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  spec.source       = { :git => "https://github.com/cyface-de/protos.git", :tag => "#{spec.version}" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  # spec.source_files = "src/main/proto/**/*.proto"
+
+  # spec.public_header_files = "Classes/**/*.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # spec.resource  = "icon.png"
+  spec.resources = "src/main/proto/**/*.proto"
+
+  # spec.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # spec.framework  = "SomeFramework"
+  # spec.frameworks = "SomeFramework", "AnotherFramework"
+
+  # spec.library   = "iconv"
+  # spec.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  # spec.requires_arc = true
+
+  # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # spec.dependency "JSONKit", "~> 1.4"
+
+end

--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,9 @@ Other message types:
 
 == Compiling the Message Definitions
 
-Generates serializer, deserializer, etc. in a chosen language, e.g. `.java` files for Java.
+Generates serializer, deserializer, etc. in a chosen language, e.g. `.java` files for Java, or `.swift` files for Swift.
+
+### Java
 
 Java classes can be compiled with link:https://developers.google.com/protocol-buffers/docs/javatutorial#compiling-your-protocol-buffers[protoc] (Protocol Buffers, version: see `protobufVersion` in `build.gradle`):
 
@@ -64,6 +66,16 @@ Or you can download the `proto` link:protoc --java_out=./src/main/java/ src/main
 
 The serializers encode the data in an efficient way, the decision process is documented link:https://cyface.atlassian.net/wiki/spaces/IM/pages/1535148033/Datenformat+bertragungsprotokoll+API+V3[internally].
 
+### Swift
+Swift classes may be generated using link:https://github.com/apple/swift-protobuf[Swift Protobuf] from Apple.
+
+You can include the `.proto` file with your Swift project from the Cyface custom Pod repository: `https://github.com/cyface-de/ios-podspecs.git` using CocoaPods:
+
+```
+pod 'Protos', '~> 1.0.0'
+```
+
+Using a custom Pods repository is explained on the link:https://guides.cocoapods.org/making/private-cocoapods.html[CocoaPods Website].
 
 == Using the generated Code
 


### PR DESCRIPTION
Should be pretty self explanatory. This enables us to include the Protos project as a CocoaPods dependency into ios projects.